### PR TITLE
Feat: Generate Article, Comment, and ArticleLike models with associations (Task6-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ yarn-debug.log*
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+# ER図ファイル（rails-erd出力）
+erd.dot
+erd.pdf

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,10 @@ inherit_from:
 
 AllCops:
   TargetRubyVersion: 2.7
+
+# 例：新しく追加された Cop に対応
+Layout/LineEndStringConcatenationIndentation:
+  Enabled: false
+
+Style/RedundantCurrentDirectoryInPath:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development do
   gem "rack-mini-profiler", "~> 2.0"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   # gem 'spring'
+  gem "rails-erd"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     byebug (12.0.0)
     case_transform (0.2)
       activesupport
+    choice (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     crass (1.0.6)
@@ -210,6 +211,11 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
+    rails-erd (1.7.2)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
@@ -228,6 +234,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rexml (3.4.1)
     rspec-core (3.13.4)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -268,6 +275,8 @@ GEM
     rubocop-rspec (3.6.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
+    ruby-graphviz (1.2.5)
+      rexml
     ruby-progressbar (1.13.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -346,6 +355,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.7, >= 6.1.7.1)
+  rails-erd
   rspec-rails (~> 4.0.1)
   rubocop-rails
   rubocop-rspec

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -19,6 +19,6 @@
 #
 class Article < ApplicationRecord
   belongs_to :user
-  has_many :comments
-  has_many :article_likes
+  has_many :comments, dependent: :destroy
+  has_many :article_likes, dependent: :destroy
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Article < ApplicationRecord
+  belongs_to :user
+  has_many :comments
+  has_many :article_likes
+end

--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: article_likes
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_article_likes_on_article_id  (article_id)
+#  index_article_likes_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class ArticleLike < ApplicationRecord
+  belongs_to :user
+  belongs_to :article
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#  index_comments_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :article
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,7 @@ class User < ApplicationRecord
 
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy
-  has_many :likes, dependent: :destroy
+  has_many :article_likes, dependent: :destroy
 
   validates :name, presence: true
 end

--- a/db/migrate/20250623132754_create_articles.rb
+++ b/db/migrate/20250623132754_create_articles.rb
@@ -1,0 +1,11 @@
+class CreateArticles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :articles do |t|
+      t.string :title
+      t.text :body
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250623133158_create_comments.rb
+++ b/db/migrate/20250623133158_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.text :body
+      t.references :user, null: false, foreign_key: true
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250623133235_create_article_likes.rb
+++ b/db/migrate/20250623133235_create_article_likes.rb
@@ -1,0 +1,10 @@
+class CreateArticleLikes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :article_likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_22_130546) do
+ActiveRecord::Schema.define(version: 2025_06_23_133235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "article_likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_article_likes_on_article_id"
+    t.index ["user_id"], name: "index_article_likes_on_user_id"
+  end
+
+  create_table "articles", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_comments_on_article_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -45,4 +73,9 @@ ActiveRecord::Schema.define(version: 2025_06_22_130546) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "article_likes", "articles"
+  add_foreign_key "article_likes", "users"
+  add_foreign_key "articles", "users"
+  add_foreign_key "comments", "articles"
+  add_foreign_key "comments", "users"
 end

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: article_likes
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_article_likes_on_article_id  (article_id)
+#  index_article_likes_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :article_like do
+    user { nil }
+    article { nil }
+  end
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :article do
+    title { "MyString" }
+    body { "MyText" }
+    user { nil }
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#  index_comments_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :comment do
+    body { "MyText" }
+    user { nil }
+    article { nil }
+  end
+end

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -18,7 +18,7 @@
 #  fk_rails_...  (article_id => articles.id)
 #  fk_rails_...  (user_id => users.id)
 #
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ArticleLike, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: article_likes
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_article_likes_on_article_id  (article_id)
+#  index_article_likes_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe ArticleLike, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe Article, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -17,7 +17,7 @@
 #
 #  fk_rails_...  (user_id => users.id)
 #
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Article, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#  index_comments_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -19,7 +19,7 @@
 #  fk_rails_...  (article_id => articles.id)
 #  fk_rails_...  (user_id => users.id)
 #
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Comment, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"


### PR DESCRIPTION
## Context

Based on the ERD designed in Task3, this PR adds the missing models: Article, Comment, and ArticleLike.  
It also establishes the appropriate associations and includes ERD output via `rails-erd`.

## Changes

- Generated models:
  - Article (title:string, body:text, user:references)
  - Comment (body:text, user:references, article:references)
  - ArticleLike (user:references, article:references)
- Added associations:
  - User: has_many :articles, :comments, :article_likes
  - Article: belongs_to :user, has_many :comments, :article_likes
  - Comment / ArticleLike: belongs_to associations defined
- Updated Gemfile to include `rails-erd` under the development group
- Ran `bundle exec rails db:migrate` and `annotate` for schema comments
- Generated ERD:
  - Used `bundle exec erd --filetype=dot` due to freezing on default output
  - Converted with `dot -Tpdf erd.dot -o erd.pdf`
  - ※ Added `.gitignore` entries to exclude `erd.dot`, `erd.pdf` from version control


## Notes

- Graphviz was installed via Homebrew (`brew install graphviz`) to support ERD output
- `User` model’s `has_many :likes` was corrected to `has_many :article_likes`
- ERD output successfully generated and included as `erd.pdf`
- No validations or scopes added yet — kept minimal for initial schema setup

## Review

- Confirm correctness of model generation and associations
- Ensure schema comments reflect intended structure (via annotate)
- Verify ERD structure visually in `erd.pdf`
- Confirm graphviz and `rails-erd` integration functions correctly in local dev

## Git-Flow

- Base branch: `develop`
- Feature branch: `feature/task6-2-generate-article-comment-articlelike`