### PR TITLE
Feat: Add API routing for Article resource (Task7-1)

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class ArticlesController < ApplicationController
+      def index
+        render json: { message: "API is working!" }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for "User", at: "auth"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  namespace :api do
+    namespace :v1 do
+      resources :articles
+    end
+  end
 end


### PR DESCRIPTION
## Context

This PR adds the initial API routing for the `Article` resource,  
setting up the `/api/v1/articles` endpoint as a foundation for the API phase.

## Changes

- Defined `namespace :api do ...` structure in `routes.rb`
- Added RESTful routes for `articles` under `/api/v1`
- Created `ArticlesController` under `Api::V1` namespace (empty or scaffolded)
- Placeholder `index` action added for initial testing

## Notes

- Confirmed `rails routes` reflects correct paths
- Tested endpoint via `GET /api/v1/articles`
- This sets up the entry point for future API implementation

## Review

- Confirm routes are correctly nested under `/api/v1`
- Verify controller is in the expected namespace
- Optionally hit the endpoint and confirm basic JSON output

## Git-Flow

- Base branch: `develop`
- Feature branch: `task7-1-article-api-routing`