### PR TITLE
Feat Add articles#show API with 404 handling (Task7-4)

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -4,4 +4,13 @@ class Api::V1::ArticlesController < ApplicationController
     render json: articles, each_serializer:
     Api::V1::ArticlePreviewSerializer
   end
+
+  def show
+    article = Article.find_by(id: params[:id])
+    if article
+      render json: article
+    else
+      head :not_found
+    end
+  end
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,3 +1,7 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :created_at, :updated_at
+  attributes :id, :title, :body, :created_at, :updated_at, :user_name
+
+  def user_name
+    object.user.name
+  end
 end

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -28,4 +28,21 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
   end
+
+  describe "GET /api/v1/articles/:id" do
+    let(:article) { create(:article) }
+
+    it "returns a specific article" do
+      get "/api/v1/articles/#{article.id}"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["id"]).to eq(article.id)
+      expect(json["title"]).to eq(article.title)
+      expect(json["user_name"]).to eq(article.user.name)
+    end
+    it "returns 404 if article is not found" do
+      get "/api/v1/articles/0"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end


### PR DESCRIPTION
## Context

This PR adds the `show` action for `ArticlesController`,
which returns a single article in JSON format via ActiveModel::Serializers (AMS).
It also includes graceful handling for non-existent articles, returning a 404 status.

## Changes
- Implemented `ArticlesController#show`
- Used `Article.find_by(id: params[:id])` with 404 fallback
- Reused `ArticleSerializer` for consistent output
- Added request specs for:
    - Successful response (`200`)
    - Not found response (`404`)
- All specs passed (`17 examples, 0 failures`)
- Rubocop passed (`68 files inspected, no offenses`)

## Notes
- Keeps JSON structure consistent with index
- Error handling prepares for robust client-side behavior