### PR TITLE
Feat: Add create action and request specs for Article API (Task7-5)

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -13,4 +13,21 @@ class Api::V1::ArticlesController < ApplicationController
       head :not_found
     end
   end
+
+  def create
+    article = Article.new(article_params)
+    article.user = User.first # 仮置き（Task8でcurrent_userに変更）
+
+    if article.save
+      render json: article, status: :created
+    else
+      render json: { errors: article.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def article_params
+      params.require(:article).permit(:title, :body)
+    end
 end

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -45,4 +45,36 @@ RSpec.describe "Api::V1::Articles", type: :request do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  describe "POST /api/v1/articles" do
+    let!(:user) { create(:user) }
+    let(:valid_params) { { article: { title: "Hello", body: "World" } } }
+
+    it "creates a new article" do
+      post "/api/v1/articles", params: valid_params
+      expect(response).to have_http_status(:created)
+
+      json = JSON.parse(response.body)
+      expect(json["title"]).to eq("Hello")
+      expect(json["body"]).to eq("World")
+    end
+    describe "POST /api/v1/articles" do
+      let(:user) { create(:user) }
+      before { user }
+      let(:valid_params) { { article: { title: "Hello", body: "World" } } }
+
+      it "creates a new article" do
+        post "/api/v1/articles", params: valid_params
+        expect(response).to have_http_status(:created)
+        json = JSON.parse(response.body)
+        expect(json["title"]).to eq("Hello")
+        expect(json["body"]).to eq("World")
+      end
+
+      it "returns error when params are invalid" do
+        post "/api/v1/articles", params: { article: { title: "" } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

This PR is part of **Task7-5** in the Wonderful_Editor project.  
The goal is to implement the `POST /api/v1/articles` endpoint so that new articles can be created via the API.  
Since authentication is not yet implemented (handled in Task8), the article is currently associated with `User.first` as a temporary measure.

## Changes

- Added `create` action in `ArticlesController` under `Api::V1::`
  - Uses `article_params` to whitelist `title` and `body`
  - Associates article with `User.first` (to be replaced by `current_user` in Task8)
- Implemented request spec:
  - Test for successful creation with valid params
  - Test for error response when params are invalid
- Ensured test stability by explicitly creating a user with `before { user }`
- Verified:
  - All RSpec tests passed
  - Rubocop passed with no offenses

## Notes

- The current `User.first` logic is a placeholder and will be updated when user authentication is introduced in upcoming tasks.
