### PR TITLE
Feat: Implement article update API with request specs and fix private method scope (Task7-6)

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -25,9 +25,19 @@ class Api::V1::ArticlesController < ApplicationController
     end
   end
 
-  private
+  def update
+    article = Article.find(params[:id])
 
-    def article_params
-      params.require(:article).permit(:title, :body)
+    if article.update(article_params)
+      render json: article
+    else
+      render json: { errors: article.errors.full_messages }, status: :unprocessable_entity
     end
+  end
+
+private
+
+  def article_params
+    params.require(:article).permit(:title, :body)
+  end
 end

--- a/config/rubocop/rubocop.yml
+++ b/config/rubocop/rubocop.yml
@@ -416,3 +416,7 @@ Style/HashTransformKeys:
 # version 1 からは強制 true
 Style/HashTransformValues:
   Enabled: true
+
+# private や protected などのアクセス修飾子の位置と、それに続くメソッドのインデントを同列にする（追加）
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -77,4 +77,45 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
   end
+
+  describe "PATCH /api/v1/articles/:id" do
+    let(:user) { create(:user) }
+    let!(:article) { create(:article, user: user) }
+
+    before { user }
+
+    context "with valid parameters" do
+      let(:update_params) do
+        {
+          article: {
+            title: "Updated Title",
+            body: "Updated Body",
+          },
+        }
+      end
+
+      it "updates the article" do
+        patch "/api/v1/articles/#{article.id}", params: update_params
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["title"]).to eq("Updated Title")
+        expect(json["body"]).to eq("Updated Body")
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_params) do
+        {
+          article: {
+            title: "",
+          },
+        }
+      end
+
+      it "returns error when title is blank" do
+        patch "/api/v1/articles/#{article.id}", params: invalid_params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

This PR completes the implementation of the article update API (`PATCH /api/v1/articles/:id`)  
as part of Task7-6. It includes controller logic, request specs, and a fix related to `private` scope handling.

## Changes

- Added `update` action to `Api::V1::ArticlesController`
- Added request specs for both valid and invalid update scenarios
- Fixed visibility issue caused by placing `update` method under `private`
- Updated `.rubocop.yml` to enforce outdented style for access modifiers

## Notes

- The `update` action was initially placed below `private`, which made it inaccessible via routing and caused ActionNotFound.
- Moving the method above `private` resolved the issue.
- Added the following to `.rubocop.yml` to fix indentation style:

  - `Layout/AccessModifierIndentation:`
    - `EnforcedStyle: outdent`

## Review

- Confirm that both `valid` and `invalid` update specs pass
- Ensure correct status codes and response formats
- Check that `rubocop` passes with the updated config

## Git-Flow

- Base branch: `develop`
- Feature branch: `feature/task7-6-articles-api-update`