### PR TITLE
Feat: Add destroy API and request spec for articles (Task7-7)

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -35,6 +35,12 @@ class Api::V1::ArticlesController < ApplicationController
     end
   end
 
+  def destroy
+    article = Article.find(params[:id])
+    article.destroy!
+    head :no_content
+  end
+
 private
 
   def article_params

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -118,4 +118,17 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
   end
+
+  describe "DELETE /api/v1/articles/:id" do
+    let(:user) { create(:user) }
+    let!(:article) { create(:article, user: user) }
+
+    it "deletes the article" do
+      expect {
+        delete "/api/v1/articles/#{article.id}"
+      }.to change(Article, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
 end


### PR DESCRIPTION
## Context

This PR implements the article deletion API (`DELETE /api/v1/articles/:id`)  
as part of Task7-7. It includes the controller action, request spec,  
and a RuboCop-guided fix for using `destroy!` to ensure proper exception handling.

## Changes

- Added `destroy` action to `Api::V1::ArticlesController`
  - Uses `destroy!` instead of `destroy` (per RuboCop suggestion)
- Added RSpec test for deletion:
  - Ensures article is deleted
  - Confirms `204 No Content` response
- No view or response body is returned on success

## Notes

- `destroy!` raises an error on failure, which improves reliability and debuggability
- Returning `head :no_content` aligns with standard RESTful practice for DELETE endpoints
- Error handling (e.g., record not found) is not included in this task but may be handled globally in the future

## Review

- Confirm `DELETE /api/v1/articles/:id` deletes the record and returns 204
- Check that RuboCop passes with the use of `destroy!`
- Confirm RSpec covers both status and DB state change

## Git-Flow

- Base branch: `develop`
- Feature branch: `feature/task7-7-articles-api-destroy`