### PR TITLE
Feat: Implement Sign Up / Sign In / Sign Out Api with DeviseTokenAuth (Task9-1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "bootsnap", ">= 1.4.4", require: false
 gem "active_model_serializers", "~> 0.10.0"
 gem "devise"
 gem "devise_token_auth"
+gem "rack-cors"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.17)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-mini-profiler (2.3.4)
       rack (>= 1.2.0)
     rack-proxy (0.7.7)
@@ -353,6 +355,7 @@ DEPENDENCIES
   pry-doc
   pry-rails
   puma (~> 5.0)
+  rack-cors
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.7, >= 6.1.7.1)
   rails-erd

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,13 +40,11 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :validatable
 
   include DeviseTokenAuth::Concerns::User
 
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
-
-  validates :name, presence: true
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,5 @@ module WonderfulEditor
                        controller_specs: false,
                        request_specs: true
     end
-
-    config.api_only = true
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,11 @@
+# config/initializers/cors.rb
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*" # 本番では限定すべき
+    resource "*",
+             headers: :any,
+             expose: ["access-token", "expiry", "token-type", "uid", "client"],
+             methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end


### PR DESCRIPTION
## Context  
Implemented authentication APIs (sign up, sign in, sign out) using DeviseTokenAuth.  
The app was originally generated without `--api` flag, but `config.api_only = true` had been set manually, causing middleware issues.  
This flag has been removed, allowing `ActionController::Base` to function with full middleware support.

## Changes  
- Installed `rack-cors` gem and ran `bundle install`  
- Added `protect_from_forgery with: :null_session` to `ApplicationController`  
- Created `config/initializers/cors.rb` with proper CORS settings  
- Updated `routes.rb` to include `mount_devise_token_auth_for`  
- Removed `config.api_only = true` to enable required middleware (e.g., Flash, Session)  
- Verified `User` model includes necessary columns:
  - `provider`: ✔︎
  - `uid`: ✔︎
- Tested via Postman:
  - ✔︎ Sign Up (`/api/v1/auth`)
  - ✔︎ Sign In (`/api/v1/auth/sign_in`)
  - ✔︎ Sign Out (`/api/v1/auth/sign_out`)
- Confirmed that `uid`, `client`, and `access-token` headers are returned and used properly in sign out requests

## Notes  
- Middleware was not functioning due to `config.api_only = true`. Removing that flag restored normal behavior for `ActionController::Base`  
- All authentication endpoints tested successfully in Postman  
- This setup forms a stable base for `current_user` handling and protected routes in later tasks

## Review  
- Are controller and middleware settings aligned with token-based auth?  
- Are the token headers handled correctly across requests?  
- Is this a suitable base for proceeding to Task9-2 (e.g., protected user info)?

## Git-Flow  
`feature/task9-1-registration` → `develop`