### PR TITLE
Feat: Add Request Spec for User Login API (Task9-3)

### DIFF
--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "User Login API", type: :request do
+  describe "POST /api/v1/auth/sign_in" do
+    let!(:user) { User.create!(email: "test@example.com", password: "password", password_confirmation: "password") }
+
+    context "with valid credentials" do
+      it "returns 200 and authentication headers" do
+        post "/api/v1/auth/sign_in", params: { email: user.email, password: "password" }
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["data"]["email"]).to eq(user.email)
+        expect(response.headers).to include("access-token", "client", "uid")
+      end
+    end
+
+    context "with invalid credentials" do
+      it "returns 401 unauthorized" do
+        post "/api/v1/auth/sign_in", params: { email: user.email, password: "wrongpassword" }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to have_key("errors")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
This PR adds request specs for the user login API (`POST /api/v1/auth/sign_in`).
The tests verify successful authentication and failure scenarios using DeviseTokenAuth.

## Changes
- Added `spec/requests/api/v1/auth/sessions_spec.rb`
- Implemented test cases for both successful and failed login scenarios:
  - Valid credentials return 200 and authentication headers
  - Invalid credentials return 401 with error messages

## Notes
- Verified that response headers include `access-token`, `client`, and `uid` upon successful login
- All tests pass ✔︎

## Review
- Are the test scenarios sufficient for login flow?
- Are header expectations clear and aligned with DeviseTokenAuth behavior?

 ## Git-Flow
 `feature/Task9-3-login_spec` → `develop`