### PR TITLE
Feat: Add Request Spec for User Logout API (Task9-4)

### DIFF
--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -23,4 +23,28 @@ RSpec.describe "User Login API", type: :request do
       end
     end
   end
+
+  describe "DELETE /api/v1/auth/sign_out" do
+    let!(:user) { User.create!(email: "test@example.com", password: "password", password_confirmation: "password") }
+    let(:auth_headers) { user.create_new_auth_token }
+
+    context "with valid token headers" do
+      it "returns 200 and clears the token" do
+        delete "/api/v1/auth/sign_out", headers: auth_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to have_key("success")
+        expect(JSON.parse(response.body)["success"]).to eq(true)
+      end
+    end
+
+    context "with missing token headers" do
+      it "returns 404 (user not found)" do
+        delete "/api/v1/auth.sign_out"
+
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to have_key("errors")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context
This PR adds request specs for the user logout API (`DELETE /api/v1/auth/sign_out`) using DeviseTokenAuth.
After confirming login behavior in Task9-3, this test verfies proper sign-out flow via token headers.

## Changes
- Added logout test to `spec/requests/api/v1/auth/sessions_spec.rb`
- Implemented test cases for:
	- Logout with valid headers returns 200 and includes success message
	- Logout without headers returns 404 (user not found)

## Notes
- Used `user.crient_new_auth_token` to generate headers for the request
- Ensured logout returns `200 OK` with `{"success: true"}`

## Review
- Is the token header usage clear and valid?
- Does the spec accurately reflect DeviseTokenAuth logout behavior?

## Git-Flow
`feature/Task9-4-logout_spec` → `develop`