### PR TITLE
Merge: Integrate Task9 - Token Auth Headers and Controller Protection(Task9)

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,8 @@
 # app/controller/api/v1/articles_controller.rb
 module Api::V1
   class ArticlesController < BaseApiController
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
+
     def index
       articles = Article.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,7 +1,6 @@
 # app/controllers/api/v1/base_api_controller.rb
 class Api::V1::BaseApiController < ApplicationController
-  # current_user のダミーコード
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,5 +47,8 @@ module WonderfulEditor
                        controller_specs: false,
                        request_specs: true
     end
+
+    config.api_only = true
+    config.middleware.use ActionDispatch::Flash
   end
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,14 +42,12 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {
-  #   :'authorization' => 'Authorization',
-  #   :'access-token' => 'access-token',
-  #   :'client' => 'client',
-  #   :'expiry' => 'expiry',
-  #   :'uid' => 'uid',
-  #   :'token-type' => 'token-type'
-  # }
+  #
+  config.headers_names = { 'access-token': "access-token",
+                           client: "client",
+                           expiry: "expiry",
+                           uid: "uid",
+                           'token-type': "token-type" }
 
   # Makes it possible to use custom uid column
   # config.other_uid = "foo"

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,12 +42,13 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  #
+
   config.headers_names = { 'access-token': "access-token",
                            client: "client",
                            expiry: "expiry",
                            uid: "uid",
-                           'token-type': "token-type" }
+                           'token-type': "token-type",
+                           'authorization': "authorization" }
 
   # Makes it possible to use custom uid column
   # config.other_uid = "foo"

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -21,7 +21,7 @@
 require "rails_helper"
 
 RSpec.describe ArticleLike, type: :model do
-  xdescribe "バリデーション" do
+  describe "バリデーション" do
     context "有効な場合" do
       it "同じユーザーが別の記事にいいねできる" do
         user = create(:user)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -22,7 +22,7 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  xdescribe "バリデーション" do
+  describe "バリデーション" do
     context "有効な場合" do
       it "すべての属性が正しければ有効である" do
         comment = build(:comment)

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe "Api::V1::Articles", type: :request do
   # omitted
 
   describe "POST /articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
 
     # stub
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token.compact }
 
     it "creates a new article record" do
       expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
@@ -23,11 +23,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token.compact }
 
     context "when updating an article owned by the current user" do
       let(:article) { create(:article, user: current_user) }
@@ -50,12 +50,12 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /articles/:id" do
-    subject { delete(api_v1_article_path(article_id)) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     # To be removed after devise_token_auth is implemented
     let(:current_user) { create(:user) }
     let(:article_id) { article.id }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token.compact }
 
     context "when the user tries to delete their own article" do
       let!(:article) { create(:article, user: current_user) }

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,78 +1,61 @@
+# spec/requests/api/v1/auth/registrations_spec.rb
 require "rails_helper"
 
-RSpec.describe "User Registration API", type: :request do
-  xdescribe "POST /api/v1/auth" do
-    let(:valid_params) do
-      {
-        email: "test@example.com",
-        password: "password",
-        password_confirmation: "password",
-      }
-    end
+RSpec.describe "Api/V1::Auth::Registrations", type: :request do
+  describe "POST /v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
 
-    context "when the request is valid" do
-      it "creates a new user and returns status 200" do
-        post "/api/v1/auth", params: valid_params
+    context "when all required information is provided" do
+      let(:params) { attributes_for(:user) }
 
+      it "registers a new user" do
+        expect { subject }.to change { User.count }.by(1)
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)["data"]["email"]).to eq(valid_params[:email])
-        expect(response.headers).to include("access-token", "client", "uid")
+        res = JSON.parse(response.body)
+        expect(res["data"]["email"]).to eq(User.last.email)
+      end
+
+      it "returns header information" do
+        subject
+        header = response.header
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(header["expiry"]).to be_present
+        expect(header["uid"]).to be_present
+        expect(header["token-type"]).to be_present
       end
     end
 
-    context "when the request is invalid" do
-      it "returns a 422 with error messages" do
-        invalid_params = valid_params.merge(password_confirmation: "wrong")
+    context "when name is missing" do
+      let(:params) { attributes_for(:user, name: nil) }
 
-        post "/api/v1/auth", params: invalid_params
+      it "returns an error" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)).to have_key("errors")
-      end
-    end
-    context "when email is already token" do
-      before { User.create!(email: valid_params[:email], password: "password", password_confirmation: "password") }
-
-      it "returns 422 with error" do
-        post "/api/v1/auth", params: valid_params
-
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)).to have_key("errors")
+        expect(res["errors"]["name"]).to include "can't be blank"
       end
     end
 
-    context "when email is blank" do
-      it "returns 422 with error" do
-        post "/api/v1/auth", params: valid_params.merge(email: "")
+    context "when email is missing" do
+      let(:params) { attributes_for(:user, email: nil) }
 
+      it "returns an error" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)).to have_key("errors")
+        expect(res["errors"]["email"]).to include "can't be blank"
       end
     end
 
-    context "when password is too short" do
-      it "returns 422 with error" do
-        post "/api/v1/auth", params: valid_params.merge(password: "123", password_confirmation: "123")
+    context "when password is missing" do
+      let(:params) { attributes_for(:user, password: nil) }
 
+      it "returns an error" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)).to have_key("errors")
-      end
-    end
-
-    context "when password confirmation does not match" do
-      it "returns 422 with error" do
-        post "/api/v1/auth", params: valid_params.merge(password_confirmation: "wrong")
-
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)).to have_key("errors")
-      end
-    end
-
-    context "when password confirmation is blank" do
-      it "returns 422 with error" do
-        post "/api/v1/auth", params: valid_params.merge(password_confirmation: "")
-
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)).to have_key("errors")
+        expect(res["errors"]["password"]).to include "can't be blank"
       end
     end
   end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -59,21 +59,22 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
       let(:user) { create(:user) }
       let!(:headers) { user.create_new_auth_token }
 
-    it "logs out successfully" do
-      expect { subject }.to change { user.reload.tokens }.from(be_present).to(be_blank)
-      expect(response).to have_http_status(:ok)
+      it "logs out successfully" do
+        expect { subject }.to change { user.reload.tokens }.from(be_present).to(be_blank)
+        expect(response).to have_http_status(:ok)
+      end
     end
-  end
 
-  context "when invalid headers are provided" do
-    let(:user) { create(:user) }
-    let!(:headers) { { "access-token" => "", "token-type" => "", "client" => "", "expiry" => "", "uid" => "" } }
+    context "when invalid headers are provided" do
+      let(:user) { create(:user) }
+      let!(:headers) { { "access-token" => "", "token-type" => "", "client" => "", "expiry" => "", "uid" => "" } }
 
-    it "fails to log out" do
-      subject
-      expect(response).to have_http_status(:not_found)
-      res = JSON.parse(response.body)
-      expect(res["errors"]).to include "User was not found or was not logged in."
+      it "fails to log out" do
+        subject
+        expect(response).to have_http_status(:not_found)
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to include "User was not found or was not logged in."
+      end
     end
   end
 end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,50 +1,79 @@
+# spec/requests/api/v1/auth/sessions_spec.rb
 require "rails_helper"
 
-RSpec.describe "User Login API", type: :request do
-  xdescribe "POST /api/v1/auth/sign_in" do
-    let!(:user) { User.create!(email: "test@example.com", password: "password", password_confirmation: "password") }
+RSpec.describe "Api::V1::Auth::Sessions", type: :request do
+  describe "POST /api/v1/auth/sign_in" do
+    subject { post(api_v1_user_session_path, params: params) }
 
-    context "with valid credentials" do
-      it "returns 200 and authentication headers" do
-        post "/api/v1/auth/sign_in", params: { email: user.email, password: "password" }
+    context "when valid registered user information is submitted" do
+      let(:user) { create(:user) }
+      let(:params) { attributes_for(:user, email: user.email, password: user.password) }
 
+      it "logs in successfully" do
+        subject
+        header = response.header
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(header["uid"]).to be_present
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)["data"]["email"]).to eq(user.email)
-        expect(response.headers).to include("access-token", "client", "uid")
       end
     end
 
-    context "with invalid credentials" do
-      it "returns 401 unauthorized" do
-        post "/api/v1/auth/sign_in", params: { email: user.email, password: "wrongpassword" }
+    context "when the email does not match" do
+      let(:user) { create(:user) }
+      let(:params) { attributes_for(:user, email: "hoge", password: user.password) }
 
+      it "fails to log in" do
+        subject
+        res = JSON.parse(response.body)
+        header = response.header
+        expect(res["errors"]).to include "Invalid login credentials. Please try again."
+        expect(header["access-token"]).to be_blank
+        expect(header["client"]).to be_blank
+        expect(header["uid"]).to be_blank
         expect(response).to have_http_status(:unauthorized)
-        expect(JSON.parse(response.body)).to have_key("errors")
+      end
+    end
+
+    context "when the password does not match" do
+      let(:user) { create(:user) }
+      let(:params) { attributes_for(:user, email: user.email, password: "hoge") }
+
+      it "fails to log in" do
+        subject
+        res = JSON.parse(response.body)
+        header = response.header
+        expect(res["errors"]).to include "Invalid login credentials. Please try again."
+        expect(header["access-token"]).to be_blank
+        expect(header["client"]).to be_blank
+        expect(header["uid"]).to be_blank
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
 
-  xdescribe "DELETE /api/v1/auth/sign_out" do
-    let!(:user) { User.create!(email: "test@example.com", password: "password", password_confirmation: "password") }
-    let(:auth_headers) { user.create_new_auth_token }
+  describe "DELETE /api/v1/auth/sign_out" do
+    subject { delete(destroy_api_v1_user_session_path, headers: headers) }
 
-    context "with valid token headers" do
-      it "returns 200 and clears the token" do
-        delete "/api/v1/auth/sign_out", headers: auth_headers
+    context "when valid logout headers are provided" do
+      let(:user) { create(:user) }
+      let!(:headers) { user.create_new_auth_token }
 
-        expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)).to have_key("success")
-        expect(JSON.parse(response.body)["success"]).to eq(true)
-      end
+    it "logs out successfully" do
+      expect { subject }.to change { user.reload.tokens }.from(be_present).to(be_blank)
+      expect(response).to have_http_status(:ok)
     end
+  end
 
-    context "with missing token headers" do
-      it "returns 404 (user not found)" do
-        delete "/api/v1/auth.sign_out"
+  context "when invalid headers are provided" do
+    let(:user) { create(:user) }
+    let!(:headers) { { "access-token" => "", "token-type" => "", "client" => "", "expiry" => "", "uid" => "" } }
 
-        expect(response).to have_http_status(:not_found)
-        expect(JSON.parse(response.body)).to have_key("errors")
-      end
+    it "fails to log out" do
+      subject
+      expect(response).to have_http_status(:not_found)
+      res = JSON.parse(response.body)
+      expect(res["errors"]).to include "User was not found or was not logged in."
     end
   end
 end


### PR DESCRIPTION
Merge: Integrate Task9 - Token Auth Headers and Controller Protection

This merge applies Task9 changes onto the existing auth foundation from Task6 and Task7.

- Adopted DeviseTokenAuth header structure
- Ensured consistent use of `current_api_v1_user` across all endpoints
- Replaced stubs with token-auth headers in specs
- Added `before_action :authenticate_user!` to API controllers
- All specs passed with full token-based authentication

This completes the Task9 reflow and prepares for final merge into `develop`.
