### PR TITLE
Feat: Add enum for Article status and basic validation tests (Task11-1)

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -23,4 +24,6 @@ class Article < ApplicationRecord
   has_many :article_likes, dependent: :destroy
 
   validates :title, presence: true
+
+  enum status: { draft: 0, published: 1 }
 end

--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -10,8 +10,9 @@
 #
 # Indexes
 #
-#  index_article_likes_on_article_id  (article_id)
-#  index_article_likes_on_user_id     (user_id)
+#  index_article_likes_on_article_id              (article_id)
+#  index_article_likes_on_user_id                 (user_id)
+#  index_article_likes_on_user_id_and_article_id  (user_id,article_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/db/migrate/20250719114106_add_status_to_articles.rb
+++ b/db/migrate/20250719114106_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_24_141325) do
+ActiveRecord::Schema.define(version: 2025_07_19_114106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2025_06_24_141325) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -10,8 +10,9 @@
 #
 # Indexes
 #
-#  index_article_likes_on_article_id  (article_id)
-#  index_article_likes_on_user_id     (user_id)
+#  index_article_likes_on_article_id              (article_id)
+#  index_article_likes_on_user_id                 (user_id)
+#  index_article_likes_on_user_id_and_article_id  (user_id,article_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -10,8 +10,9 @@
 #
 # Indexes
 #
-#  index_article_likes_on_article_id  (article_id)
-#  index_article_likes_on_user_id     (user_id)
+#  index_article_likes_on_article_id              (article_id)
+#  index_article_likes_on_user_id                 (user_id)
+#  index_article_likes_on_user_id_and_article_id  (user_id,article_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -16,6 +17,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (user_id => users.id)
+#
 
 # articles_spec.rb
 require "rails_helper"
@@ -39,6 +41,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       expect(res[0]["user"].keys).to eq ["id", "name", "email"]
     end
   end
+
   describe "GET /articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
@@ -66,6 +69,20 @@ RSpec.describe "Api::V1::Articles", type: :request do
       it "raises a not found error" do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
+    end
+  end
+
+  describe "status" do
+    it "can be saved as draft" do
+      article = create(:article, status: :draft)
+      expect(article).to be_valid
+      expect(article.draft?).to be true
+    end
+
+    it "can be saved as published" do
+      article = create(:article, status: :published)
+      expect(article).to be_valid
+      expect(article.published?).to be true
     end
   end
 end


### PR DESCRIPTION
## Context
This PR implements a basic draft functionality using enum in the Article model for Task11-1.
It introduces `status` with values `draft` and `published`.

## Changes
- Added enum `status` to Article model
- Implemented unit tests for:
  - Saving articles as draft
  - Saving articles as published

## Notes
- This is the foundation for filtering articles by status in future API updates (Task11-2, 11-3)
- Confirmed that status persists correctly in test DB

## Review
- Are enum values suitable and semantically clear?
- Are test cases sufficient for this stage?

## Git-Flow
`feature/Task11-1-article_draft_enum` → `develop`