### PR TITLE
Feat: Add API to list current user's published articles (Task12)

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,15 @@
+# app/controllers/api/v1/current/articles_controller.rb
+module Api
+  module V1
+    module Current
+      class ArticlesController < BaseApiController
+        before_action :authenticate_user!
+
+        def index
+          articles = current_user.articles.published.order(updated_at: :desc)
+          render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+        end
+      end
+    end
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -26,4 +26,6 @@ class Article < ApplicationRecord
   validates :title, presence: true
 
   enum status: { draft: 0, published: 1 }
+
+  scope :published, -> { where(status: "published") }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,10 @@ Rails.application.routes.draw do
       get "articles/drafts", to: "articles/drafts#index"
       get "articles/drafts/:id", to: "articles/drafts#show"
       resources :articles
+
+      namespace :current do
+        resources :articles, only: [:index]
+      end
     end
   end
 end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,19 @@
+# spec/requests/api/v1/current/articles_spec.rb
+require "rails_helper"
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    let(:user) { create(:user) }
+    let!(:published_article) { create(:article, user: user, status: "published") }
+    let!(:draft_article) { create(:article, user: user, status: "draft") }
+    let!(:other_article) { create(:article, status: "published") }
+
+    it "returns only current user's published articles" do
+      get "/api/v1/current/articles", headers: user.create_new_auth_token
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json.length).to eq(1)
+      expect(json.first["id"]).to eq(published_article.id)
+    end
+  end
+end


### PR DESCRIPTION
## Context
This PR adds an endpoint to retrieve all published articles authored by the currently logged-in user.
It supports use cases like rendering a "My Page" with authored posts.

## Changes
- Added endpoint: `GET /api/v1/current/articles`
- Scoped query to current_user's published articles ordered by updated_at
- Added request spec for current user's article list

## Notes
- Authentication required
- Reuses ArticlePreviewSerializer for consistency with public index

## Review
- Does the endpoint return only current_user's published articles?
- Is the route design (`/current/articles`) intuitive and REST-friendly?
- Are specs thorough for both data and auth behavior?

## Git-Flow
`feature/Task12-user_published_articles` → `develop`