### PR TITLE
Fix: correct branch name in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     env: ruby
     region: singapore
     plan: free
-    branch: master
+    branch: deploy/wonderful_editor_final
     numInstances: 1
     healthCheckPath: /
     buildCommand: ./bin/render-build.sh

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     env: ruby
     region: singapore
     plan: free
-    branch: deploy/wonderful_editor_final
+    branch: develop
     numInstances: 1
     healthCheckPath: /
     buildCommand: ./bin/render-build.sh


### PR DESCRIPTION
## Context
The previous `render.yaml` file pointed to the `master` branch, which does not exist in this repository. This caused a Render deployment error.

## Changes
- Updated `render.yaml` to use `develop` as the target branch for deployment.

## Notes
Render Blueprint now recognizes the correct branch and can deploy without errors.

## Git-Flow
`deploy/wonderful_editor_final` → `develop`
